### PR TITLE
Avoid use of prefix in Swift functions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -130,19 +130,6 @@ extension MyExtension {
 }
 ```
 
-**Preferred:**
-```swift
-extension MyExtension where Base: UIColor {
-    func colorToImage() -> UIImage {
-        let color = self.base
-
-        // function to convert color to image
-
-        return image
-    }
-}
-```
-
 **Not Preferred:**
 ```swift
 func prefix_someFunctionName() -> Bool

--- a/README.markdown
+++ b/README.markdown
@@ -112,9 +112,20 @@ let myClass = MyModule.UsefulClass()
 
 Following same pattern as for class names, function names shouldn't be prefixed. Prefixes for functions is mostly used in extensions in order to avoid function name collisions, but in Swift, if a function has the same name as another function defined in another module or a private function the compiler raise a compilation error.
 
+There is one exception in this rule:
+A prefix should be used in the case of exposing a function name to Objective-C code using @objc() in and extension in order to avoid runtime exceptions due to Objective-C dynamism.
+
 **Preferred:**
 ```swift
 extension MyExtension {
+    func functionName()
+}
+```
+
+**Preferred:**
+```swift
+extension MyExtension {
+    @objc(prefix_functionName)
     func functionName()
 }
 ```

--- a/README.markdown
+++ b/README.markdown
@@ -108,6 +108,35 @@ import SomeModule
 let myClass = MyModule.UsefulClass()
 ```
 
+### Functions Prefixes
+
+Following same pattern as for class names, function names shouldn't be prefixed. Prefixes for functions is mostly used in extensions in order to avoid function name collisions, but in Swift, if a function has the same name as another function defined in another module or a private function the compiler raise a compilation error.
+
+**Preferred:**
+```swift
+extension MyExtension {
+    func functionName()
+}
+```
+
+**Preferred:**
+```swift
+extension MyExtension where Base: UIColor {
+    func colorToImage() -> UIImage {
+        let color = self.base
+
+        // function to convert image to color
+
+        return image
+    }
+}
+```
+
+**Not Preferred:**
+```swift
+func prefix_someFunctionName() -> Bool
+```
+
 ### Delegates
 
 When creating custom delegate methods, an unnamed first parameter should be the delegate source. (UIKit contains numerous examples of this.)

--- a/README.markdown
+++ b/README.markdown
@@ -125,7 +125,7 @@ extension MyExtension where Base: UIColor {
     func colorToImage() -> UIImage {
         let color = self.base
 
-        // function to convert image to color
+        // function to convert color to image
 
         return image
     }


### PR DESCRIPTION
Added new rule and some example to avoid using functions prefixes in Swift code